### PR TITLE
Disable linting on push for all git branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
   push:
+    paths: ["main", "develop"]
 
 jobs:
   lint-typecheck:


### PR DESCRIPTION
Currently, the lint job runs twice for every pull request – once on push and again on the pull request event. I believe this is redundant, considering that merges directly to main or develop can only occur through a pull request. Thus, I suggest restricting linting **on push** to only main and develop branches to reduce CI runtime